### PR TITLE
[dnsrocks] fix dnstap message type (#11)

### DIFF
--- a/dnsrocks/logger/dnstap_logger.go
+++ b/dnsrocks/logger/dnstap_logger.go
@@ -137,7 +137,7 @@ func (l *DNSTapLoggger) Log(state request.Request, r *dns.Msg, ecs *dns.EDNS0_SU
 		glog.Errorf("Failed to set ResponseAddress %v for dnstap message", state.W.RemoteAddr())
 	}
 	msg.SetQueryTime(m, time.Now())
-	msg.SetType(m, dnstap.Message_CLIENT_QUERY)
+	msg.SetType(m, dnstap.Message_AUTH_QUERY)
 	buf, _ = r.Pack()
 	m.QueryMessage = buf
 


### PR DESCRIPTION
**What:**

Fix #11  by using Message_AUTH_QUERY as the dnstap message type

**Checklist**:



- [ ] Added tests, if you've added code that should be tested N/A
- [ ] Updated the documentation, if you've changed APIs N/A
- [X] Ensured the test suite passes
- [X] Made sure your code lints
- [X] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
