### PR TITLE
Fix lint after golangci-lint 1.52 update

### DIFF
--- a/dnsrocks/cgo-rocksdb/options.go
+++ b/dnsrocks/cgo-rocksdb/options.go
@@ -98,8 +98,7 @@ func (options *Options) EnableStatistics() {
 
 // GetStatisticsString returns stats string
 func (options *Options) GetStatisticsString() string {
-	var cStat *C.char
-	cStat = C.rocksdb_options_statistics_get_string(options.cOptions)
+	cStat := C.rocksdb_options_statistics_get_string(options.cOptions)
 	defer C.rocksdb_free(unsafe.Pointer(cStat))
 	return C.GoString(cStat)
 }

--- a/dnsrocks/cmd/dnsrocks-selftest/dnsrocks-selftest.go
+++ b/dnsrocks/cmd/dnsrocks-selftest/dnsrocks-selftest.go
@@ -97,10 +97,7 @@ func doWork(dbConfig dnsserver.DBConfig, nets []*net.IPNet, workers int, qType, 
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return g.Wait()
 }
 
 func verifyMaps() error {

--- a/dnsrocks/dnsdata/parser.go
+++ b/dnsrocks/dnsdata/parser.go
@@ -137,10 +137,7 @@ func parse(r io.Reader, process func([]byte) error, workers int) error {
 	wg.Wait()
 
 	// Check we have reached EOF properly
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-	return nil
+	return scanner.Err()
 }
 
 // Parse parses data from Reader in parallel, wrapping ParseStream

--- a/dnsrocks/dnsdata/rdb/rdb_test.go
+++ b/dnsrocks/dnsdata/rdb/rdb_test.go
@@ -35,15 +35,15 @@ type mockedDB struct {
 	delete   func(key []byte) error
 }
 
-func (mock *mockedDB) Put(writeOptions *rocksdb.WriteOptions, key, value []byte) error {
+func (mock *mockedDB) Put(_ *rocksdb.WriteOptions, key, value []byte) error {
 	return mock.put(key, value)
 }
 
-func (mock *mockedDB) Get(readOptions *rocksdb.ReadOptions, key []byte) ([]byte, error) {
+func (mock *mockedDB) Get(_ *rocksdb.ReadOptions, key []byte) ([]byte, error) {
 	return mock.get(key)
 }
 
-func (mock *mockedDB) Delete(writeOptions *rocksdb.WriteOptions, key []byte) error {
+func (mock *mockedDB) Delete(_ *rocksdb.WriteOptions, key []byte) error {
 	return mock.delete(key)
 }
 
@@ -55,7 +55,7 @@ func (mock *mockedDB) GetMulti(readOptions *rocksdb.ReadOptions, keys [][]byte) 
 	return mock.getMulti(readOptions, keys)
 }
 
-func (mock *mockedDB) ExecuteBatch(batch *rocksdb.Batch, writeOptions *rocksdb.WriteOptions) error {
+func (mock *mockedDB) ExecuteBatch(_ *rocksdb.Batch, _ *rocksdb.WriteOptions) error {
 	return nil
 }
 func (mock *mockedDB) CatchWithPrimary() error {
@@ -68,7 +68,7 @@ func (mock *mockedDB) Flush() error {
 
 func (mock *mockedDB) CompactRangeAll() {}
 
-func (mock *mockedDB) IngestSSTFiles(files []string, useHardlinks bool) error {
+func (mock *mockedDB) IngestSSTFiles(_ []string, _ bool) error {
 	return nil
 }
 

--- a/dnsrocks/dnsdata/svcb/unmarshallers.go
+++ b/dnsrocks/dnsdata/svcb/unmarshallers.go
@@ -56,8 +56,7 @@ func alpnUnmarshaller(input []byte, out *bytes.Buffer) {
 }
 
 // no-default-alpn should print no value
-func nodefaultalpnUnmarshaller(input []byte, out *bytes.Buffer) {
-}
+func nodefaultalpnUnmarshaller(_ []byte, _ *bytes.Buffer) {}
 
 func portUnmarshaller(input []byte, out *bytes.Buffer) {
 	port := binary.BigEndian.Uint16(input)

--- a/dnsrocks/dnsserver/logger.go
+++ b/dnsrocks/dnsserver/logger.go
@@ -36,7 +36,7 @@ type TextLogger struct {
 }
 
 // Log is used to log to an ioWriter.
-func (l *TextLogger) Log(state request.Request, r *dns.Msg, ecs *dns.EDNS0_SUBNET) {
+func (l *TextLogger) Log(state request.Request, _ *dns.Msg, _ *dns.EDNS0_SUBNET) {
 	fmt.Fprintf(l.IoWriter, "[%s] %s %s %s\n",
 		state.IP(), strings.ToUpper(state.Proto()),
 		state.Name(), state.Type())
@@ -53,9 +53,7 @@ func (l *TextLogger) LogFailed(state request.Request, r *dns.Msg, ecs *dns.EDNS0
 type DummyLogger struct{}
 
 // Log is used to log to an ioWriter.
-func (l *DummyLogger) Log(state request.Request, r *dns.Msg, ecs *dns.EDNS0_SUBNET) {}
+func (l *DummyLogger) Log(_ request.Request, _ *dns.Msg, _ *dns.EDNS0_SUBNET) {}
 
 // LogFailed is used to log failures
-func (l *DummyLogger) LogFailed(state request.Request, r *dns.Msg, ecs *dns.EDNS0_SUBNET) {
-
-}
+func (l *DummyLogger) LogFailed(_ request.Request, _ *dns.Msg, _ *dns.EDNS0_SUBNET) {}

--- a/dnsrocks/dnsserver/stats/ctr.go
+++ b/dnsrocks/dnsserver/stats/ctr.go
@@ -42,5 +42,5 @@ func (s Counters) IncrementCounter(key string) {
 }
 
 // AddSample is not implemented here
-func (s Counters) AddSample(key string, value int64) {
+func (s Counters) AddSample(_ string, _ int64) {
 }

--- a/dnsrocks/dnsserver/stats/stats.go
+++ b/dnsrocks/dnsserver/stats/stats.go
@@ -27,16 +27,16 @@ type DummyStats struct {
 }
 
 // ResetCounterTo stub implementation
-func (s *DummyStats) ResetCounterTo(key string, value int64) {}
+func (s *DummyStats) ResetCounterTo(_ string, _ int64) {}
 
 // ResetCounter stub implementation
-func (s *DummyStats) ResetCounter(key string) {}
+func (s *DummyStats) ResetCounter(_ string) {}
 
 // IncrementCounterBy stub implementation
-func (s *DummyStats) IncrementCounterBy(key string, value int64) {}
+func (s *DummyStats) IncrementCounterBy(_ string, _ int64) {}
 
 // IncrementCounter stub implementation
-func (s *DummyStats) IncrementCounter(key string) {}
+func (s *DummyStats) IncrementCounter(_ string) {}
 
 // AddSample stub implementation
-func (s *DummyStats) AddSample(key string, value int64) {}
+func (s *DummyStats) AddSample(_ string, _ int64) {}

--- a/dnsrocks/dnsserver/test/responsewriter.go
+++ b/dnsrocks/dnsserver/test/responsewriter.go
@@ -34,7 +34,7 @@ type ResponseWriterCustomRemote struct {
 }
 
 // WriteMsg implement dns.ResponseWriter interface.
-func (t *ResponseWriter) WriteMsg(m *dns.Msg) error { t.writeMsgCallCount++; return nil }
+func (t *ResponseWriter) WriteMsg(_ *dns.Msg) error { t.writeMsgCallCount++; return nil }
 
 // GetWriteMsgCallCount returns the number of WriteMsg calls that were made.
 func (t *ResponseWriter) GetWriteMsgCallCount() uint64 { return t.writeMsgCallCount }

--- a/dnsrocks/fbserver/server.go
+++ b/dnsrocks/fbserver/server.go
@@ -511,7 +511,7 @@ func joinAddress(host string, port int) string {
 // reusePort sets a UNIX socket option that allows the listener to bind to a
 // port that is already in use. The delegation of traffic to listeners is
 // equally distributed via this method.
-func reusePort(network, address string, c syscall.RawConn) error {
+func reusePort(_, _ string, c syscall.RawConn) error {
 	var opErr error
 	err := c.Control(func(fd uintptr) {
 		opErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)

--- a/dnsrocks/logger/dnstap_logger.go
+++ b/dnsrocks/logger/dnstap_logger.go
@@ -119,7 +119,7 @@ func (l *DNSTapLoggger) StartLoggerOutput() {
 }
 
 // Log is used to log to dnstap.
-func (l *DNSTapLoggger) Log(state request.Request, r *dns.Msg, ecs *dns.EDNS0_SUBNET) {
+func (l *DNSTapLoggger) Log(state request.Request, r *dns.Msg, _ *dns.EDNS0_SUBNET) {
 	// FIXME: implement Bad_query, EDNS_FORMERR, EDNS_BADVERS
 
 	// We only sample non-sonar names

--- a/dnsrocks/metrics/metrics_dummy.go
+++ b/dnsrocks/metrics/metrics_dummy.go
@@ -18,7 +18,7 @@ type DummyServer struct {
 }
 
 // NewDummyMetricsServer creates a new dummy metrics server
-func NewDummyMetricsServer(addr string) (server *DummyServer, err error) {
+func NewDummyMetricsServer(_ string) (server *DummyServer, err error) {
 	return &DummyServer{}, nil
 }
 
@@ -32,7 +32,7 @@ func (s *DummyServer) SetAlive() {
 }
 
 // ConsumeStats for dummy metrics server does nothing
-func (s *DummyServer) ConsumeStats(category string, stats *Stats) error {
+func (s *DummyServer) ConsumeStats(_ string, _ *Stats) error {
 	return nil
 }
 


### PR DESCRIPTION
**What:**

Address lint issues related to golangci refresh.

**Why:**

Make lint green again!

**How:**

By me typing on the keyboard.

**Risks:**

Nope

**Checklist**:

- [ ] Added tests, if you've added code that should be tested
- [ ] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
