### PR TITLE
wait for compactions to finish in applydiff

### DIFF
--- a/dnsrocks/dnsdata/rdb/applydiff.go
+++ b/dnsrocks/dnsdata/rdb/applydiff.go
@@ -18,7 +18,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"os"
+	"time"
 
 	"github.com/facebookincubator/dns/dnsrocks/dnsdata"
 	"github.com/facebookincubator/dns/dnsrocks/dnsdata/rdb/dbdiff"
@@ -59,6 +61,20 @@ func (rdb *RDB) ApplyDiff(r io.Reader, serial uint32) error {
 	}
 	if err := rdb.ExecuteBatch(batch); err != nil {
 		return fmt.Errorf("database update failed: %w", err)
+	}
+	log.Printf("waiting for potential compactions to finish")
+	for {
+		stats := rdb.GetStats()
+		numComp, ok := stats["rocksdb.num-running-compactions"]
+		if !ok {
+			log.Printf("cannot find \"rocksdb.num-running-compactions\" key in RocksDB stats, unable to wait for potential compactions to finish")
+			break
+		}
+		log.Printf("currently running compactions: %d", numComp)
+		if numComp == 0 {
+			break
+		}
+		time.Sleep(time.Second)
 	}
 	return nil
 }


### PR DESCRIPTION
Summary: Turns out RDB does compactions in background thread, and doesn't wait on it when closed. Explicitly wait for "rocksdb.num-running-compactions" to turn 0 after applying changes.

Reviewed By: deathowl

Differential Revision: D45081882

