### PR TITLE
better sliding window

### DIFF
--- a/dnsrocks/go.mod
+++ b/dnsrocks/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/coredns/coredns v1.10.0
 	github.com/dnstap/golang-dnstap v0.4.0
+	github.com/eclesh/welford v0.0.0-20150116075914-eec62615b1f0
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/glog v1.0.0
 	github.com/golang/mock v1.6.0

--- a/dnsrocks/go.sum
+++ b/dnsrocks/go.sum
@@ -70,6 +70,8 @@ github.com/dgryski/go-spooky v0.0.0-20170606183049-ed3d087f40e2 h1:lx1ZQgST/imDh
 github.com/dgryski/go-spooky v0.0.0-20170606183049-ed3d087f40e2/go.mod h1:hgHYKsoIw7S/hlWtP7wD1wZ7SX1jPTtKko5X9jrOgPQ=
 github.com/dnstap/golang-dnstap v0.4.0 h1:KRHBoURygdGtBjDI2w4HifJfMAhhOqDuktAokaSa234=
 github.com/dnstap/golang-dnstap v0.4.0/go.mod h1:FqsSdH58NAmkAvKcpyxht7i4FoBjKu8E4JUPt8ipSUs=
+github.com/eclesh/welford v0.0.0-20150116075914-eec62615b1f0 h1:kQ0PoUSzoqBCdOXbrrZtBGHZOs46U8Aj0BG1Xa+tq7w=
+github.com/eclesh/welford v0.0.0-20150116075914-eec62615b1f0/go.mod h1:Lt9Nv8E2/1kmk2nD0nTZTae7qFRCXPJV6q7Debf1An8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/dnsrocks/metrics/stats.go
+++ b/dnsrocks/metrics/stats.go
@@ -15,7 +15,6 @@ package metrics
 
 import (
 	"fmt"
-	"sort"
 	"sync"
 	"time"
 
@@ -112,21 +111,10 @@ func (stats *Stats) Get() map[string]int64 {
 	stats.vlock.Unlock()
 	stats.wlock.Lock()
 	for key, val := range stats.windows {
-		samples := val.Samples()
-		sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
-		if len(samples) > 0 {
-			ret[fmt.Sprintf("%s.min", key)] = samples[0]
-			ret[fmt.Sprintf("%s.max", key)] = samples[len(samples)-1]
-			var sum int64
-			for _, numb := range samples {
-				sum += numb
-			}
-			ret[fmt.Sprintf("%s.avg", key)] = sum / int64(len(samples))
-		} else {
-			ret[fmt.Sprintf("%s.min", key)] = 0
-			ret[fmt.Sprintf("%s.max", key)] = 0
-			ret[fmt.Sprintf("%s.avg", key)] = 0
-		}
+		s := val.Stats()
+		ret[fmt.Sprintf("%s.min", key)] = s.min
+		ret[fmt.Sprintf("%s.max", key)] = s.max
+		ret[fmt.Sprintf("%s.avg", key)] = s.avg
 	}
 	stats.wlock.Unlock()
 	return ret


### PR DESCRIPTION
Summary:
We only use aggregates from all the samples we store in sliding window.
When we are hit with 80k QPS and have sliding window of 60s, it means we store and process 4.8 million stat samples, each storing time and value itself. It's not cheap, both memory wise (golang's Time is relatively big, storing two 64bit ints for time itself plus a pointer to Location, so at least 24 bytes on 64bit system).

We then copy those slices of values many times, and eventually sort all those millions of samples to get min/max and avg.

**But what if I tell you that we don't need to store the samples at all?**

Instead, we store a ring buffer of N aggregates (which are very cheap thanks to Welford algorithm).
This allows us to keep 'sliding' aggregates while not bothering with removal of outdated samples.

Reviewed By: deathowl

Differential Revision: D45698916

