### PR TITLE
Add current time to debug info

### DIFF
--- a/dnsrocks/debuginfo/common.go
+++ b/dnsrocks/debuginfo/common.go
@@ -14,6 +14,9 @@ limitations under the License.
 package debuginfo
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/coredns/coredns/request"
 
 	"github.com/facebookincubator/dns/dnsrocks/db"
@@ -29,10 +32,22 @@ type Pair struct {
 }
 
 // InfoSrc is defined to enable mocking of [GetInfo].
-type InfoSrc func(request.Request) []Pair
+type InfoSrc interface {
+	GetInfo(request.Request) []Pair
+}
 
-func makeInfo(state request.Request) []Pair {
+type infoSrc struct {
+	created time.Time
+}
+
+// MakeInfoSrc creates an InfoSrc that captures the current creation time.
+func MakeInfoSrc() InfoSrc {
+	return infoSrc{created: time.Now()}
+}
+
+func (i infoSrc) baseInfo(state request.Request) []Pair {
 	info := []Pair{
+		{Key: "time", Val: fmt.Sprintf("%.3f", float64(i.created.UnixMilli())/1000.)},
 		{Key: "protocol", Val: logger.RequestProtocol(state)},
 		{Key: "source", Val: state.RemoteAddr()},
 	}

--- a/dnsrocks/debuginfo/debuginfo_oss.go
+++ b/dnsrocks/debuginfo/debuginfo_oss.go
@@ -18,6 +18,6 @@ import (
 )
 
 // GetInfo returns the debug info related to this request.
-func GetInfo(state request.Request) []Pair {
-	return makeInfo(state)
+func (i infoSrc) GetInfo(state request.Request) []Pair {
+	return i.baseInfo(state)
 }

--- a/dnsrocks/whoami/whoami.go
+++ b/dnsrocks/whoami/whoami.go
@@ -29,14 +29,14 @@ import (
 // representing the Handler
 type Handler struct {
 	whoamiDomain string
-	getInfo      debuginfo.InfoSrc
+	infoGen      func() debuginfo.InfoSrc
 	Next         plugin.Handler
 }
 
 // NewWhoami initializes a new whoami Handler.
 func NewWhoami(d string) (*Handler, error) {
 	wh := new(Handler)
-	wh.getInfo = debuginfo.GetInfo
+	wh.infoGen = debuginfo.MakeInfoSrc
 	wh.whoamiDomain = strings.ToLower(dns.Fqdn(d))
 	return wh, nil
 }
@@ -59,7 +59,7 @@ func (wh *Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 			rr.(*dns.TXT).Txt = []string{fmt.Sprintf("%s %s", key, value)}
 			return rr
 		}
-		for _, pair := range wh.getInfo(state) {
+		for _, pair := range wh.infoGen().GetInfo(state) {
 			m.Answer = append(m.Answer, mkTxt(pair.Key, pair.Val))
 		}
 	}


### PR DESCRIPTION
Summary:
When debug info is included in an error report, an embedded timestamp is useful to clarify when the info was collected.

Note that this change affects both NSID and any "whoami" TXT records.

Differential Revision: D47159899

