### PR TITLE
Update options file for RocksDB

### DIFF
--- a/dnsrocks/cgo-rocksdb/options.go
+++ b/dnsrocks/cgo-rocksdb/options.go
@@ -188,6 +188,7 @@ func (options *Options) SetCompactOnDeletion(windowSize int, numDelsTrigger int)
 		options.cOptions,
 		C.size_t(windowSize),
 		C.size_t(numDelsTrigger),
+		C.double(0.0),
 	)
 }
 


### PR DESCRIPTION
Summary: There is an API change in RocksDB. So update rocksdb_options_add_compact_on_deletion_collector_factory to take into account deletion_ratio.
https://github.com/facebook/rocksdb/pull/11542

Differential Revision: D47060125

