### PR TITLE
Run dnsrocks CI pipeline against rocksdb head

### DIFF
--- a/.github/scripts/install_rocks_head.sh
+++ b/.github/scripts/install_rocks_head.sh
@@ -10,5 +10,7 @@ deb http://archive.ubuntu.com/ubuntu/ kinetic-updates multiverse
 
 apt-get update -qq
 
-apt-get install -qq librocksdb7.3
-apt-get install -qq librocksdb-dev
+apt-get install libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev libzstd-dev liblz4-dev
+git clone https://github.com/facebook/rocksdb.git
+cd rocksdb || exit
+PREFIX=/usr make install-shared

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,11 +5,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v2
         with:
           go-version: 1.18
       - name: "Install Rocks"
-        run: sudo bash .github/scripts/install_rocks_7.sh
+        run: sudo bash .github/scripts/install_rocks_head.sh
       - uses: golangci/golangci-lint-action@v3
         with:
           working-directory: dnsrocks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,15 @@ jobs:
     env:
       CGO_LDFLAGS_ALLOW: .*
       CGO_CFLAGS_ALLOW: .*
-
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v2
         with:
           go-version: 1.18
       - name: install rocksdb
-        run: sudo bash .github/scripts/install_rocks_7.sh
+        run: sudo bash .github/scripts/install_rocks_head.sh
       - name : Compile
         run: cd dnsrocks; go build -v ./...
       - name: Test


### PR DESCRIPTION

**What:**

Fetches and compiles rocksdb head, to run CI Pipeline against

**Why:**

* Enables us to catch regressions early
* Enables us to have a perftest node against the latest rocksdb source (tbd)
**How:**

fetches and builds rocksdb head instead of installing the prebuilt package from the package manager 
**Risks:**
Slower builds

**Checklist**:

- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")
