### PR TITLE
Add support for private debug info

### DIFF
--- a/dnsrocks/debuginfo/common.go
+++ b/dnsrocks/debuginfo/common.go
@@ -15,6 +15,7 @@ package debuginfo
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/coredns/coredns/request"
@@ -31,6 +32,17 @@ type Pair struct {
 	Val string
 }
 
+// Print renders a list of pairs in key=value format.
+func Print(pairs []Pair) string {
+	var components []string
+	for _, pair := range pairs {
+		if pair.Val != "" {
+			components = append(components, fmt.Sprintf("%s=%s", pair.Key, pair.Val))
+		}
+	}
+	return strings.Join(components, " ")
+}
+
 // InfoSrc is defined to enable mocking of [GetInfo].
 type InfoSrc interface {
 	GetInfo(request.Request) []Pair
@@ -40,12 +52,13 @@ type infoSrc struct {
 	created time.Time
 }
 
-// MakeInfoSrc creates an InfoSrc that captures the current creation time.
-func MakeInfoSrc() InfoSrc {
+// makeInfoSrc creates an InfoSrc that captures the current creation time.
+func makeInfoSrc() InfoSrc {
 	return infoSrc{created: time.Now()}
 }
 
-func (i infoSrc) baseInfo(state request.Request) []Pair {
+// GetInfo returns the debug info related to this request.
+func (i infoSrc) GetInfo(state request.Request) []Pair {
 	info := []Pair{
 		{Key: "time", Val: fmt.Sprintf("%.3f", float64(i.created.UnixMilli())/1000.)},
 		{Key: "protocol", Val: logger.RequestProtocol(state)},

--- a/dnsrocks/debuginfo/debuginfo_oss.go
+++ b/dnsrocks/debuginfo/debuginfo_oss.go
@@ -13,11 +13,7 @@ limitations under the License.
 
 package debuginfo
 
-import (
-	"github.com/coredns/coredns/request"
-)
-
-// GetInfo returns the debug info related to this request.
-func (i infoSrc) GetInfo(state request.Request) []Pair {
-	return i.baseInfo(state)
+// Generator returns the InfoSrc generating function.
+func Generator() func() InfoSrc {
+	return makeInfoSrc
 }

--- a/dnsrocks/debuginfo/debuginfo_test.go
+++ b/dnsrocks/debuginfo/debuginfo_test.go
@@ -56,9 +56,11 @@ func TestWithoutECS(t *testing.T) {
 			req.SetQuestion(dns.Fqdn("example.com."), dns.TypeTXT)
 			state := request.Request{W: w, Req: req}
 
-			before := time.Now().UnixMilli()
+			makeInfoSrc := Generator()
 			time.Sleep(2 * time.Millisecond) // Ensure that times are different after rounding
-			infoSrc := MakeInfoSrc()
+			before := time.Now().UnixMilli()
+			time.Sleep(2 * time.Millisecond)
+			infoSrc := makeInfoSrc()
 			time.Sleep(2 * time.Millisecond)
 			after := time.Now().UnixMilli()
 			info := infoSrc.GetInfo(state)
@@ -128,7 +130,7 @@ func TestWithECS(t *testing.T) {
 			req.Extra = []dns.RR{o}
 			state := request.Request{W: w, Req: req}
 
-			info := MakeInfoSrc().GetInfo(state)
+			info := Generator()().GetInfo(state)
 
 			require.Equal(t, info[0].Key, "time", "missing time key")
 			info = info[1:]

--- a/dnsrocks/logger/utils.go
+++ b/dnsrocks/logger/utils.go
@@ -83,7 +83,11 @@ type Config struct {
 func RequestProtocol(state request.Request) string {
 	proto := state.Proto() // Protocol used
 	if proto == "tcp" {
-		if tls := state.W.(dns.ConnectionStater).ConnectionState(); tls != nil {
+		var tls *tls.ConnectionState
+		if stater, ok := state.W.(dns.ConnectionStater); ok {
+			tls = stater.ConnectionState()
+		}
+		if tls != nil {
 			if p, ok := TLSVersionStrings[tls.Version]; ok {
 				proto = p
 			} else {

--- a/dnsrocks/nsid/nsid.go
+++ b/dnsrocks/nsid/nsid.go
@@ -16,8 +16,6 @@ package nsid
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
-	"strings"
 
 	"github.com/facebookincubator/dns/dnsrocks/debuginfo"
 
@@ -36,7 +34,7 @@ type Handler struct {
 // NewHandler produces a new NSID insertion handler.
 func NewHandler() (*Handler, error) {
 	h := new(Handler)
-	h.infoGen = debuginfo.MakeInfoSrc
+	h.infoGen = debuginfo.Generator()
 	return h, nil
 }
 
@@ -69,11 +67,7 @@ func (w nsidResponseWriter) WriteMsg(response *dns.Msg) error {
 		glog.Errorf("no EDNS for NSID")
 	} else {
 		state := request.Request{W: w, Req: w.request}
-		var components []string
-		for _, pair := range w.infoSrc.GetInfo(state) {
-			components = append(components, fmt.Sprintf("%s=%s", pair.Key, pair.Val))
-		}
-		nsid := strings.Join(components, " ")
+		nsid := debuginfo.Print(w.infoSrc.GetInfo(state))
 		opt.Option = append(opt.Option, &dns.EDNS0_NSID{
 			Code: dns.EDNS0NSID,
 			Nsid: hex.EncodeToString([]byte(nsid)),

--- a/dnsrocks/whoami/whoami.go
+++ b/dnsrocks/whoami/whoami.go
@@ -36,7 +36,7 @@ type Handler struct {
 // NewWhoami initializes a new whoami Handler.
 func NewWhoami(d string) (*Handler, error) {
 	wh := new(Handler)
-	wh.infoGen = debuginfo.MakeInfoSrc
+	wh.infoGen = debuginfo.Generator()
 	wh.whoamiDomain = strings.ToLower(dns.Fqdn(d))
 	return wh, nil
 }


### PR DESCRIPTION
Summary:
This change adds an encrypted section called "private" to the debug TXT records and NSID output, containing information (such as the internal hostname) that may not be appropriate to disclose publicly.

This is an alternative to D47304715.

Reviewed By: yarikk

Differential Revision: D47448961

